### PR TITLE
Adjust search paths for protos and output dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM golang:1.20-alpine
 
 RUN apk add --no-cache protobuf protobuf-dev git
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.30.0
+RUN go install github.com/twitchtv/twirp/protoc-gen-twirp@latest
 
 RUN mkdir /cmd
 COPY entrypoint.sh /cmd/entrypoint.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,7 +5,8 @@ cd $1
 
 git config --global --add safe.directory '*'
 
-protoc --go_out=go *.proto
+protoc -I. --go_out=go protos/*.proto
+protoc -I. --go_out=go --twirp_out=go protos/api/*.proto
 
 git diff
 git diff-index --quiet HEAD


### PR DESCRIPTION
See related changes in https://github.com/project-echo/server-robot-upload-commspec/pull/23 .
In addition to message types, commspec now also stores robot-facing upload service definition. Twirp server is also generated there.