### PR TITLE
Upgrade Go, pin all tool versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM golang:1.24-alpine
+FROM golang:1.26-alpine
 
 RUN apk add --no-cache protobuf protobuf-dev git
-RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.30.0
-RUN go install github.com/twitchtv/twirp/protoc-gen-twirp@latest
+RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.11
+RUN go install github.com/twitchtv/twirp/protoc-gen-twirp@v8.1.3
 
 RUN mkdir /cmd
 COPY entrypoint.sh /cmd/entrypoint.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e -x -o pipefail
 
-cd "$1"
+cd "${1:-.}"
 
 git config --global --add safe.directory '*'
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e -x -o pipefail
 
-cd $1
+cd "$1"
 
 git config --global --add safe.directory '*'
 


### PR DESCRIPTION
## Summary
- Upgrade Go base image from 1.24 to 1.26
- Pin `protoc-gen-twirp` to `v8.1.3` (was `@latest`)
- Upgrade `protoc-gen-go` from `v1.30.0` to `v1.36.11`
- Quote shell variable in `entrypoint.sh`

## Test plan
- [x] Docker image builds successfully with all pinned versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)